### PR TITLE
Add possibility the modify param name when API changes any key.

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ main(){
     };
 
     Person person = dson.fromJson(
-      jsonMap, 
+      jsonMap,
       Person.new,
       inner: {
         'owner':  Person.new,
@@ -69,7 +69,7 @@ main(){
 
 ## A complex object with List:
 
-For work with a list, it is necessary to declare the constructor in the `inner` property and declare 
+For work with a list, it is necessary to declare the constructor in the `inner` property and declare
 the list resolver in the `resolvers` property.
 
 ```dart
@@ -115,4 +115,52 @@ main(){
 
 DSON Have `ListParam` and `SetParam` for collection.
 
+## When API replace Param Name:
 
+You need to declare within the paramNameReplace map the object type that has changed in the key, and in the value, a map with the old key as the key and the new key as the value.
+
+```dart
+main(){
+    final jsonMap = {
+      'id': 1,
+      'name': 'MyHome',
+      'master': {
+        'key': 1,
+        'name': 'Joshua Clak',
+        'age': 3,
+      },
+      'parents': [
+        {
+          'key': 2,
+          'name': 'Kepper Vidal',
+          'age': 25,
+        },
+        {
+          'key': 3,
+          'name': 'Douglas Bisserra',
+          'age': 23,
+        },
+      ],
+    };
+
+    Home home = dson.fromJson(
+      // json Map or List
+      jsonMap,
+      // Main constructor
+      Home.new,
+      // external types
+      inner: {
+        'owner': Person.new,
+        'parents': ListParam<Person>(Person.new),
+      },
+      // Param names Object <-> Param name in API
+      paramNameReplace: {
+        Home: {'owner': 'master'},
+        Person: {'id': 'key'}
+      }
+    );
+
+    print(home);
+}
+
+```

--- a/lib/src/param.dart
+++ b/lib/src/param.dart
@@ -6,6 +6,7 @@ abstract class IParam<T> {
     dynamic map,
     Map<String, dynamic> inner,
     List<Object Function(String, dynamic)> resolvers,
+    Map<Type, Map<String, String>> paramNameReplace,
   );
 }
 
@@ -20,6 +21,7 @@ class ListParam<T> implements IParam<List<T>> {
     covariant List map,
     Map<String, dynamic> inner,
     List<Object Function(String, dynamic)> resolvers,
+    Map<Type, Map<String, String>> paramNameReplace,
   ) {
     final typedList = map
         .map((e) {
@@ -28,6 +30,7 @@ class ListParam<T> implements IParam<List<T>> {
             constructor,
             inner: inner,
             resolvers: resolvers,
+            paramNameReplace: paramNameReplace,
           );
         })
         .toList()
@@ -48,6 +51,7 @@ class SetParam<T> implements IParam<Set<T>> {
     covariant List map,
     Map<String, dynamic> inner,
     List<Object Function(String, dynamic)> resolvers,
+    Map<Type, Map<String, String>> paramNameReplace,
   ) {
     final typedList = map
         .map((e) {
@@ -56,6 +60,7 @@ class SetParam<T> implements IParam<Set<T>> {
             constructor,
             inner: inner,
             resolvers: resolvers,
+            paramNameReplace: paramNameReplace,
           );
         })
         .toSet()

--- a/test/src/dson_base_test.dart
+++ b/test/src/dson_base_test.dart
@@ -95,8 +95,66 @@ void main() {
     expect(home.parents[1].age, 23);
   });
 
+  test('fromJson convert map in Home (inner object) when API modify name key',
+      () {
+    final jsonMap = {
+      'id': 1,
+      'name': 'MyHome',
+      'master': {
+        'key': 1,
+        'name': 'Joshua Clak',
+        'age': 3,
+      },
+      'parents': [
+        {
+          'key': 2,
+          'name': 'Kepper Vidal',
+          'age': 25,
+        },
+        {
+          'key': 3,
+          'name': 'Douglas Bisserra',
+          'age': 23,
+        },
+      ],
+    };
+
+    Home home = dson.fromJson(
+      // json Map or List
+      jsonMap,
+      // Main constructor
+      Home.new,
+      // external types
+      inner: {
+        'owner': Person.new,
+        'parents': ListParam<Person>(Person.new),
+      },
+      // Param names Object <-> Param name in API
+      paramNameReplace: {
+        Home: {'owner': 'master'},
+        Person: {'id': 'key'}
+      },
+    );
+
+    expect(home.id, 1);
+    expect(home.name, 'MyHome');
+    expect(home.owner, isA<Person>());
+    expect(home.owner.id, 1);
+    expect(home.owner.name, 'Joshua Clak');
+    expect(home.owner.age, 3);
+
+    expect(home.parents[0].id, 2);
+    expect(home.parents[0].name, 'Kepper Vidal');
+    expect(home.parents[0].age, 25);
+
+    expect(home.parents[1].id, 3);
+    expect(home.parents[1].name, 'Douglas Bisserra');
+    expect(home.parents[1].age, 23);
+  });
+
   test('fromJson works only named params constructor', () {
-    expect(() => dson.fromJson({}, (String name) {}), throwsA(isA<ParamsNotAllowed>()));
+    expect(() => dson.fromJson({}, (String name) {}),
+        throwsA(isA<ParamsNotAllowed>()));
   });
 
   test('throws error if dont has required param', () {
@@ -105,7 +163,8 @@ void main() {
       'age': 3,
     };
 
-    expect(() => dson.fromJson(jsonMap, Person.new), throwsA(isA<DSONException>()));
+    expect(() => dson.fromJson(jsonMap, Person.new),
+        throwsA(isA<DSONException>()));
   });
 }
 


### PR DESCRIPTION
When an external API changes a parameter, as far as I understand from the package, it is not possible to dynamically change this key in complex objects without having to change the object or manipulate the Map before calling fromMap(). Therefore, I added a way to do this dynamically by passing the Type and a map of object keys to API keys.

In addition, I added a test and documentation for this new feature.