### PR TITLE
Allow nullable and required parameters

### DIFF
--- a/lib/src/dson.dart
+++ b/lib/src/dson.dart
@@ -108,9 +108,18 @@ class DSON {
 
             if (value == null) {
               if (param.isRequired) {
-                throw DSONException(
-                  'Param $className.${param.name} is required.',
-                );
+                if (param.isNullable) {
+                  final entry = MapEntry(
+                    Symbol(param.name),
+                    null,
+                  );
+                  return entry;
+                } else {
+                  throw DSONException(
+                    'Param $className.${param.name} '
+                    'is required and non-nullable.',
+                  );
+                }
               } else {
                 return null;
               }
@@ -164,10 +173,11 @@ class _FunctionParam {
 
     var type = elements.last;
 
-    final isNullable = type.contains('?');
+    final lastMarkQuestionIndex = type.lastIndexOf('?');
+    final isNullable = lastMarkQuestionIndex == type.length - 1;
 
     if (isNullable) {
-      type = type.replaceFirst('?', '');
+      type = type.replaceFirst('?', '', lastMarkQuestionIndex);
     }
 
     final isRequired = elements.contains('required');

--- a/test/src/dson_base_test.dart
+++ b/test/src/dson_base_test.dart
@@ -12,12 +12,14 @@ void main() {
       'id': 1,
       'name': 'Joshua Clak',
       'age': 3,
+      'nickname': 'Josh',
     };
 
-    final person = dson.fromJson(jsonMap, Person.new);
+    final person = dson.fromJson<Person>(jsonMap, Person.new);
     expect(person.id, 1);
     expect(person.name, 'Joshua Clak');
     expect(person.age, 3);
+    expect(person.nickname, 'Josh');
   });
 
   test('fromJson convert map in Person withless name', () {
@@ -102,7 +104,7 @@ void main() {
     );
   });
 
-  test('throws error if dont has required param', () {
+  test('throws error if dont has non-nullable required param [id]', () {
     final jsonMap = {
       'name': 'Joshua Clak',
       'age': 3,
@@ -248,18 +250,81 @@ void main() {
 
     expect(primitive.destinationAddresses, list);
   });
+
+  test(
+      'fromJson should allow '
+      'to have required and nullable parameters simultaneously', () {
+    // arrange
+    final jsonMap = {
+      'id': 1,
+      'age': 3,
+    };
+
+    // act
+    final person = dson.fromJson<Person>(jsonMap, Person.new);
+
+    // assert
+    expect(person.age, 3); // not required and non-nullable
+    expect(person.name, null); // not required and nullable
+    expect(person.id, 1); // required and non-nullable
+    expect(person.nickname, null); // required and nullable
+  });
+
+  test(
+      'fromJson convert map in Person '
+      'with required and nullable param nickname equal null', () {
+    // arrange
+    final jsonMap = {
+      'id': 1,
+      'age': 3,
+      'name': 'Joshua Clak',
+    };
+
+    // act
+    final person = dson.fromJson<Person>(jsonMap, Person.new);
+
+    // assert
+    expect(person.id, 1);
+    expect(person.age, 3);
+    expect(person.name, 'Joshua Clak');
+    expect(person.nickname, 'Joshua Clak');
+  });
+
+  test(
+      'Given a list [List<Object?>] is not nullable, '
+      'When the converted json for this list is null, '
+      'Then it should throw an exception of type [DSONException] '
+      'instead of [TypeError]', () {
+    // arrange
+    final errorsSnapshotJson = {'errors': null};
+
+    // act, assert
+    expect(
+      () => dson.fromJson<ErrorsSnapshot>(
+        errorsSnapshotJson,
+        ErrorsSnapshot.new,
+      ),
+      throwsA(
+        predicate(
+          (e) => e is DSONException && e is! TypeError,
+        ),
+      ),
+    );
+  });
 }
 
 class Person {
   final int id;
   final String? name;
   final int age;
+  final String? nickname;
 
   Person({
     required this.id,
     this.name,
     this.age = 20,
-  });
+    required String? nickname,
+  }) : nickname = nickname ?? name;
 
   @override
   String toString() => 'PersonModel(id: $id, name: $name, age: $age)';
@@ -284,4 +349,9 @@ class PrimitiveList {
   PrimitiveList({
     required this.destinationAddresses,
   });
+}
+
+class ErrorsSnapshot {
+  final List<String?> errors;
+  ErrorsSnapshot({required this.errors});
 }


### PR DESCRIPTION
First of all, congratulations for the package, it's really cool not to need build_runner, and to have explicit and self-explanatory errors, good idea!

While it's not very common to need both required and nullable parameters simultaneously for most general use cases, I would suggest separating what is required from what is nullable. That way we would be more in line with Dart's features, and probably more flexible for more specific and unpredictable future cases.

- [feat] To stay as closely as possible with Dart language features, required parameters are no longer implicitly non-nullable.
- [bugfix] Fix nullable type checking when generic types are present (double question mark "List<String?>?")

![image](https://user-images.githubusercontent.com/3827308/232264462-611557f7-2d56-4e1d-b81e-3b77f57070f0.png)
![image](https://user-images.githubusercontent.com/3827308/232264511-af2d3e0e-49cb-486d-bdf3-7170a9b9983e.png)
