### PR TITLE
Adiciona novos tipos de erros [ParamUnknown, ParamNullNotAllowed, ParamInvalidType] e torna publico o [FunctionParam]

### DIFF
--- a/lib/src/errors/dson_exception.dart
+++ b/lib/src/errors/dson_exception.dart
@@ -49,8 +49,8 @@ class ParamUnknown extends DSONException {
     this.paramName,
     StackTrace? stackTrace,
   }) : super(
-          'Unknown error while trying parse parameter [$paramName] on class'
-          ' [$parentClass]',
+          "Unknown error while trying parse parameter '$paramName' on class"
+          " '$parentClass'",
           stackTrace,
         );
 
@@ -72,8 +72,8 @@ class ParamNullNotAllowed extends DSONException {
     StackTrace? stackTrace,
     required this.parentClass,
   }) : super(
-          "$parentClass({${functionParam.isRequired ? 'required ' : ''}"
-          '$functionParam})'
+          "Param '${functionParam.name}' from $parentClass"
+          '({required $functionParam})'
           "${functionParam.alias != null ? " with alias"
               " '${functionParam.alias}'," : ''}"
           ' is required and non-nullable, but the value is null or some alias'
@@ -156,7 +156,7 @@ class ParamInvalidType extends DSONException {
   }) {
     return ParamInvalidType(
       "Type not iterable '$receivedType' is not a subtype of type"
-      " [$parentClass]${functionParam.alias != null ? " with alias '"
+      " '$parentClass'${functionParam.alias != null ? " with alias '"
           "${functionParam.alias}'." : '.'}",
       stackTrace,
       receivedType: receivedType,

--- a/lib/src/errors/dson_exception.dart
+++ b/lib/src/errors/dson_exception.dart
@@ -1,3 +1,7 @@
+import 'package:collection/collection.dart';
+
+import '../../dson_adapter.dart';
+
 /// Exception from DSON
 class DSONException implements Exception {
   /// Message for exception
@@ -9,13 +13,13 @@ class DSONException implements Exception {
   /// Exception from DSON
   DSONException(this.message, [this.stackTrace]);
 
-  String get _className => 'DSONException';
+  String get _className => '[DSONException]';
 
   @override
   String toString() {
     var message = '$_className: ${this.message}';
     if (stackTrace != null) {
-      message = '$message\n$stackTrace';
+      message = '$message\n\n$stackTrace';
     }
 
     return message;
@@ -28,5 +32,136 @@ class ParamsNotAllowed extends DSONException {
   ParamsNotAllowed(super.message, [super.stackTrace]);
 
   @override
-  String get _className => 'ParamsNotAllowed';
+  String get _className => '[ParamsNotAllowed]';
+}
+
+/// Called when param is unknown and the library is not able to handle it
+class ParamUnknown extends DSONException {
+  /// The name of the class that contains the param
+  final String? parentClass;
+
+  /// Param name
+  final String? paramName;
+
+  /// Called when param is unknown and the library is not able to handle it
+  ParamUnknown({
+    this.parentClass,
+    this.paramName,
+    StackTrace? stackTrace,
+  }) : super(
+          'Unknown error while trying parse parameter [$paramName] on class'
+          ' [$parentClass]',
+          stackTrace,
+        );
+
+  @override
+  String get _className => '[ParamUnknown]';
+}
+
+/// Called when value is null, but params is required and non-nullable
+class ParamNullNotAllowed extends DSONException {
+  /// the representation of the param
+  final FunctionParam functionParam;
+
+  /// The name of the class that contains the param
+  final String parentClass;
+
+  /// Called when value is null, but params is required and non-nullable
+  ParamNullNotAllowed({
+    required this.functionParam,
+    StackTrace? stackTrace,
+    required this.parentClass,
+  }) : super(
+          "$parentClass({${functionParam.isRequired ? 'required ' : ''}"
+          '$functionParam})'
+          "${functionParam.alias != null ? " with alias"
+              " '${functionParam.alias}'," : ''}"
+          ' is required and non-nullable, but the value is null or some alias'
+          ' is missing.',
+          stackTrace,
+        );
+
+  @override
+  String get _className => '[ParamNullNotAllowed]';
+}
+
+/// Called when params is not the correct type
+class ParamInvalidType extends DSONException {
+  /// the representation of the param
+  final FunctionParam functionParam;
+
+  /// The type of param received in json
+  final String receivedType;
+
+  /// The name of the class that contains the param
+  final String parentClass;
+
+  /// Called when params is not the correct type
+  ParamInvalidType(
+    super.message,
+    super.stackTrace, {
+    required this.receivedType,
+    required this.functionParam,
+    required this.parentClass,
+  });
+
+  @override
+  String get _className => '[ParamInvalidType]';
+
+  /// Called when params is not the correct type
+  factory ParamInvalidType.typeError({
+    required Error error,
+    required String parentClass,
+    required Iterable<FunctionParam> functionParams,
+    StackTrace? stackTrace,
+  }) {
+    final typeErrorAsString = error.toString();
+
+    final errorSplitted = typeErrorAsString.split("'");
+    final receivedType = errorSplitted[1];
+    final paramName = errorSplitted[5];
+
+    final functionParam = functionParams.firstWhereOrNull(
+      (element) => element.name == paramName,
+    );
+
+    if (functionParam == null) {
+      throw ParamUnknown(
+        stackTrace: stackTrace,
+        parentClass: parentClass,
+        paramName: paramName,
+      );
+    }
+
+    return ParamInvalidType(
+      "Type '$receivedType' is not a subtype of type '${functionParam.type}' of"
+      " '$parentClass({${functionParam.isRequired ? 'required ' : ''}"
+      "$functionParam})'${functionParam.alias != null ? " with alias '"
+          "${functionParam.alias}'." : '.'}",
+      stackTrace,
+      receivedType: receivedType,
+      functionParam: functionParam,
+      parentClass: parentClass,
+    );
+  }
+
+  /// This is called when the value expected should have a
+  /// subscritor operator ([]), but the incoming value in json
+  /// is not iterable (e.g.: not a List, Set or Map)
+  factory ParamInvalidType.notIterable({
+    required String receivedType,
+    required FunctionParam functionParam,
+    required String parentClass,
+    required StackTrace? stackTrace,
+  }) {
+    return ParamInvalidType(
+      "Type not iterable '$receivedType' is not a subtype of type"
+      " [$parentClass]${functionParam.alias != null ? " with alias '"
+          "${functionParam.alias}'." : '.'}",
+      stackTrace,
+      receivedType: receivedType,
+      functionParam: functionParam,
+      parentClass: parentClass,
+    );
+  }
 }

--- a/lib/src/param.dart
+++ b/lib/src/param.dart
@@ -80,3 +80,79 @@ class SetParam<T> implements IParam<Set<T>> {
     return typedList;
   }
 }
+
+/// Used to represent a parameter
+class FunctionParam {
+  /// Type of parameter
+  final String type;
+
+  /// Name of parameter
+  final String name;
+
+  /// If parameter is required
+  final bool isRequired;
+
+  /// If parameter is nullable
+  final bool isNullable;
+
+  /// Alias of parameter
+  final String? alias;
+
+  /// Used to represent a parameter
+  FunctionParam({
+    required this.type,
+    required this.name,
+    required this.isRequired,
+    required this.isNullable,
+    this.alias,
+  });
+
+  /// Return [String] using alias or name
+  String get aliasOrName => alias ?? name;
+
+  /// Create a [FunctionParam] from [String]
+  factory FunctionParam.fromString(String paramText) {
+    final elements = paramText.split(' ');
+
+    final name = elements.last;
+    elements.removeLast();
+
+    var type = elements.last;
+
+    final lastMarkQuestionIndex = type.lastIndexOf('?');
+    final isNullable = lastMarkQuestionIndex == type.length - 1;
+
+    if (isNullable) {
+      type = type.replaceFirst('?', '', lastMarkQuestionIndex);
+    }
+
+    final isRequired = elements.contains('required');
+
+    return FunctionParam(
+      name: name,
+      type: type,
+      isRequired: isRequired,
+      isNullable: isNullable,
+    );
+  }
+
+  @override
+  String toString() => '$type $name';
+
+  /// Copy this instance with new values
+  FunctionParam copyWith({
+    String? type,
+    String? name,
+    bool? isRequired,
+    bool? isNullable,
+    String? alias,
+  }) {
+    return FunctionParam(
+      type: type ?? this.type,
+      name: name ?? this.name,
+      isRequired: isRequired ?? this.isRequired,
+      isNullable: isNullable ?? this.isNullable,
+      alias: alias ?? this.alias,
+    );
+  }
+}

--- a/test/src/dson_base_test.dart
+++ b/test/src/dson_base_test.dart
@@ -311,6 +311,307 @@ void main() {
       ),
     );
   });
+
+  test(
+      'Given id is a parameter of type int, '
+      'When the json contains a value of type String, '
+      'Then it should throw an exception of type [ParamInvalidType]', () {
+    final jsonMap = {
+      'id': '1',
+      'name': 'Joshua Clak',
+      'age': 3,
+      'nickname': 'Josh',
+    };
+
+    expect(
+      () => dson.fromJson(jsonMap, Person.new),
+      throwsA(
+        predicate(
+          (e) =>
+              e is ParamInvalidType &&
+              e.functionParam.type == 'int' &&
+              e.receivedType == 'String',
+        ),
+      ),
+    );
+  });
+
+  test(
+      'Given [key] is an alias of the parameter [id], '
+      'And [id] is a parameter of type [int], '
+      'When the json contains a value of type [String], '
+      'Then it should throw an exception of type [ParamInvalidType]', () {
+    final jsonMap = {
+      'key': '1',
+      'name': 'Joshua Clak',
+      'age': 3,
+      'nickname': 'Josh',
+    };
+
+    expect(
+      () => dson.fromJson(
+        jsonMap,
+        Person.new,
+        aliases: {
+          Person: {'id': 'key'}
+        },
+      ),
+      throwsA(
+        predicate(
+          (e) =>
+              e is ParamInvalidType &&
+              e.functionParam.type == 'int' &&
+              e.receivedType == 'String' &&
+              e.functionParam.alias == 'key',
+        ),
+      ),
+    );
+  });
+
+  test(
+      'Given [key] is an alias of the parameter [id], '
+      'And [key] was not specified in the [aliases] property, '
+      'And [key] is INCORRECTLY typed, '
+      'When [dson.fromJson] is called, '
+      'Then it should throw an exception of type [ParamNullNotAllowed]', () {
+    final jsonMap = {
+      'key': '1',
+      'name': 'Joshua Clak',
+      'age': 3,
+      'nickname': 'Josh',
+    };
+
+    expect(
+      () => dson.fromJson(
+        jsonMap,
+        Person.new,
+      ),
+      throwsA(isA<ParamNullNotAllowed>()),
+    );
+  });
+
+  test(
+      'Given [key] is an alias of the parameter [id], '
+      'And [key] was not specified in the [aliases] property, '
+      'And [key] is typed CORRECT, '
+      'When [dson.fromJson] is called, '
+      'Then it should throw an exception of type [ParamNullNotAllowed]', () {
+    final jsonMap = {
+      'key': 1,
+      'name': 'Joshua Clak',
+      'age': 3,
+      'nickname': 'Josh',
+    };
+
+    expect(
+      () => dson.fromJson(
+        jsonMap,
+        Person.new,
+      ),
+      throwsA(isA<ParamNullNotAllowed>()),
+    );
+  });
+
+  test(
+      'Since [parents] is a list of [Pearson], '
+      'When the value of [parents] is a list of [List], '
+      'Then it should throw an error [ParamUnknown] ', () {
+    final jsonMap = {
+      'id': 1,
+      'name': 'MyHome',
+      'owner': {
+        'id': 1,
+        'name': 'Joshua Clak',
+        'age': 3,
+      },
+      'parents': [[]]
+    };
+
+    expect(
+      () => dson.fromJson(
+        jsonMap,
+        Home.new,
+        inner: {
+          'owner': Person.new,
+          'parents': ListParam<Person>(Person.new),
+        },
+      ),
+      throwsA(
+        predicate((e) => e is ParamUnknown && e.parentClass == 'Person'),
+      ),
+    );
+  });
+
+  test(
+      'Since [parents] is a list of [Pearson], '
+      'When the value of [parents] is a list of [String] '
+      '(not iterable object), Then it should throw a [ParamInvalidType] error ',
+      () {
+    final jsonMap = {
+      'id': 1,
+      'name': 'MyHome',
+      'owner': {
+        'id': 1,
+        'name': 'Joshua Clak',
+        'age': 3,
+      },
+      'parents': ['']
+    };
+
+    expect(
+      () => dson.fromJson(
+        jsonMap,
+        Home.new,
+        inner: {
+          'owner': Person.new,
+          'parents': ListParam<Person>(Person.new),
+        },
+      ),
+      throwsA(
+        predicate(
+          (e) =>
+              e is ParamInvalidType &&
+              e.parentClass == 'Person' &&
+              e.receivedType == 'String' &&
+              e.message ==
+                  "Type not iterable 'String' is not a subtype of type "
+                      '[Person].',
+        ),
+      ),
+    );
+  });
+
+  test(
+      'Since [owner] is of type [Person], '
+      'And has the alias [owner_alias] '
+      'When the value of [owner] is a [String], '
+      'Then it should throw a [ParamInvalidType] error', () {
+    final jsonMap = {
+      'id': 1,
+      'name': 'MyHome',
+      'owner_alias': '',
+      'parents': [],
+    };
+
+    expect(
+      () => dson.fromJson(
+        jsonMap,
+        Home.new,
+        inner: {
+          'owner': Person.new,
+          'parents': ListParam<Person>(Person.new),
+        },
+        aliases: {
+          Home: {
+            'owner': 'owner_alias',
+          },
+        },
+      ),
+      throwsA(
+        predicate(
+          (e) =>
+              e is ParamInvalidType &&
+              e.parentClass == 'Home' &&
+              e.receivedType == 'String' &&
+              e.functionParam.type == 'Person' &&
+              e.functionParam.alias == 'owner_alias' &&
+              e.functionParam.name == 'owner',
+        ),
+      ),
+    );
+  });
+
+  test(
+      'Since home [name] is of type [String], '
+      'When the value of [name] is a [_Map<String, Object>], '
+      'Then it should throw a [ParamInvalidType] error', () {
+    final jsonMap = {
+      'id': 1,
+      'name': {
+        'id': 1,
+        'name': 'Joshua Clak',
+        'age': 3,
+      },
+      'owner': {
+        'id': 2,
+        'name': 'Father',
+        'age': 4,
+      },
+      'parents': [],
+    };
+
+    expect(
+      () => dson.fromJson(
+        jsonMap,
+        Home.new,
+        inner: {
+          'owner': Person.new,
+          'parents': ListParam<Person>(Person.new),
+        },
+      ),
+      throwsA(
+        predicate(
+          (e) =>
+              e is ParamInvalidType &&
+              e.parentClass == 'Home' &&
+              (e.receivedType == '_Map<String, Object>' ||
+                  e.receivedType == '_InternalLinkedHashMap<String, Object>') &&
+              e.functionParam.type == 'String' &&
+              e.functionParam.name == 'name',
+        ),
+      ),
+    );
+  });
+
+  test(
+      'Since home [name] is of type [String], '
+      'When the value of [name] is a [List<Map<String, Object>>], '
+      'And [name] has the alias [name_alias], '
+      'Then it should throw a [ParamInvalidType] error', () {
+    final jsonMap = {
+      'id': 1,
+      'name_alias': [
+        {
+          'id': 2,
+          'name': 'Father',
+          'age': 4,
+        }
+      ],
+      'owner': {
+        'id': 2,
+        'name': 'Father',
+        'age': 4,
+      },
+      'parents': [],
+    };
+
+    expect(
+      () => dson.fromJson(
+        jsonMap,
+        Home.new,
+        inner: {
+          'owner': Person.new,
+          'parents': ListParam<Person>(Person.new),
+        },
+        aliases: {
+          Home: {
+            'name': 'name_alias',
+          },
+        },
+      ),
+      throwsA(
+        predicate(
+          (e) =>
+              e is ParamInvalidType &&
+              e.parentClass == 'Home' &&
+              e.receivedType == 'List<Map<String, Object>>' &&
+              e.functionParam.type == 'String' &&
+              e.functionParam.name == 'name' &&
+              e.functionParam.alias == 'name_alias',
+        ),
+      ),
+    );
+  });
 }
 
 class Person {

--- a/test/src/dson_base_test.dart
+++ b/test/src/dson_base_test.dart
@@ -413,6 +413,59 @@ void main() {
   });
 
   test(
+      'Given [key] is an alias of the parameter [id], '
+      'And [key] is specified in the [aliases] property, '
+      'And [key] value is null, '
+      'When [dson.fromJson] is called, '
+      'Then it should throw an exception of type [ParamNullNotAllowed]', () {
+    final jsonMap = {
+      'key': null,
+      'name': 'Joshua Clak',
+      'age': 3,
+      'nickname': 'Josh',
+    };
+
+    expect(
+      () => dson.fromJson(
+        jsonMap,
+        Person.new,
+        aliases: {
+          Person: {
+            'id': 'key',
+          }
+        },
+      ),
+      throwsA(isA<ParamNullNotAllowed>()),
+    );
+  });
+
+  test(
+      'Given [key] is an alias of the parameter [id], '
+      'And [key] is specified in the [aliases] property, '
+      'And [key] is not present in the json, '
+      'When [dson.fromJson] is called, '
+      'Then it should throw an exception of type [ParamNullNotAllowed]', () {
+    final jsonMap = {
+      'name': 'Joshua Clak',
+      'age': 3,
+      'nickname': 'Josh',
+    };
+
+    expect(
+      () => dson.fromJson(
+        jsonMap,
+        Person.new,
+        aliases: {
+          Person: {
+            'id': 'key',
+          }
+        },
+      ),
+      throwsA(isA<ParamNullNotAllowed>()),
+    );
+  });
+
+  test(
       'Since [parents] is a list of [Pearson], '
       'When the value of [parents] is a list of [List], '
       'Then it should throw an error [ParamUnknown] ', () {
@@ -475,7 +528,7 @@ void main() {
               e.receivedType == 'String' &&
               e.message ==
                   "Type not iterable 'String' is not a subtype of type "
-                      '[Person].',
+                      "'Person'.",
         ),
       ),
     );


### PR DESCRIPTION
Olá @jacobaraujo7, eu sei que não alinhei isso antes, mas estava sentindo falta de ter tratamentos para erros relacionados a tipagem incorreta. Agradeço se puder avaliar a feature e fazer um code review. 

### Houve break changes?
- Não houve break changes, a utilização da lib continua a mesma.

### O que foi adicionado ou alterado?
- a classe `FunctionParam` se tornou pública, isso possibilitará no futuro a utilização das propriedades dela para tratamento e log de erros customizados pelo cliente.
- Foi adicionado a propriedade `String? alias` na classe `FunctionParam`.
- Além de uma pequena melhoria na padronização de mensagens de erros dos parâmetros required non-null, foi adicionado também tratamentos para tipagem incorreta.
  - `ParamNullNotAllowed` disparado quando um parâmetro é obrigatório e não pode ser `null`.
  - `ParamInvalidType` disparado quando o tipo recebido no json não é compatível com o tipo do parâmetro esperado.
  - `ParamUnknown` : disparado quando a lib recebe um parâmetro inválido e por isso não consegue determinar como deve ser feito o parse apropriado. Tipo um erro interno da lib.

### Screenshots
<img width="771" alt="Screenshot 2023-05-01 at 19 31 57" src="https://user-images.githubusercontent.com/3827308/235546360-222b1e33-c367-41a0-b1b2-875cccde067d.png">

<img width="656" alt="Screenshot 2023-05-01 at 19 09 54" src="https://user-images.githubusercontent.com/3827308/235546463-95ab7107-79c6-437d-b6ed-76f3d71b8fa9.png">

<img width="680" alt="Screenshot 2023-05-01 at 19 08 59" src="https://user-images.githubusercontent.com/3827308/235547049-f1999a88-4225-4688-9958-aa54ab122bdf.png">


<img width="784" alt="Screenshot 2023-05-01 at 19 11 33" src="https://user-images.githubusercontent.com/3827308/235546541-83b1d16d-478f-44ba-9b02-abb796442e4a.png">



 