### PR TITLE
pass resolvers to inner elements

### DIFF
--- a/lib/src/dson.dart
+++ b/lib/src/dson.dart
@@ -97,6 +97,7 @@ class DSON {
                   value = fromJson(
                     workflow,
                     innerParam,
+                    resolvers: resolvers,
                     aliases: aliases,
                   );
                 } else {


### PR DESCRIPTION
Dado o seguinte json

```json
{
  "sub": "Cliente",
  "jti": "42d11a6a-ace7-4d94-92a9-d7fd6cc6dba6",
  "expiration": 1717010123,
  "usuario": {
    "profile": "PARTNER",
    "nome": "Cliente Exemplo"
  },
}
```

Sabendo que o `profile` é um enum eu crio

```dart
enum Profile{
  partner('PARTNER'),
  seller('SELLER'),

  final String name;
  const Profile(this.name);
}
```

E uso o resolver para mapear a string que vem do backend para um campo do enum

```dart
DSON().fromJson<DecodedToken>(
  jwtToken,
  DecodedToken.new,
  inner: {'usuario': User.new},
  resolvers: [(key, value) {
    if (key == 'profile') {
      return Profile.values.firstWhere((profile) => profile.name == value);
    }
    return value;
  }],
);
```

Porém os resolvers só são considerados para os elementos na raiz do root, quando é feita a recursão para o elemento `usuario` não é passado os dados de resolvers

![image](https://github.com/Flutterando/dson_adapter/assets/22757108/aeae3000-8ad0-4a43-a6f4-af837061d6a8)


O que faz com que não seja possivel tratar os elementos aninhandos com resolvers
Minha solução foi apenas de infomar os resolvers na chamada recursiva.